### PR TITLE
"observer_" not a variable in scope.

### DIFF
--- a/leaflet-marker.html
+++ b/leaflet-marker.html
@@ -648,8 +648,8 @@ Element which defines a maker  (<a href="http://leafletjs.com/reference.html#mar
 			if (this.container && this.feature) {
 				this.container.removeLayer(this.feature);
 			}
-			if (observer_) {
-				observer.disconnect();
+			if (this.observer_) {
+				this.observer_.disconnect();
 			}
 		}
 


### PR DESCRIPTION
This fixed a stack trace when removing a leaflet-marker node from my leaflet-map.
