### PR TITLE
Fix typo on method name causing errors

### DIFF
--- a/leaflet-layer-group.html
+++ b/leaflet-layer-group.html
@@ -44,11 +44,11 @@ A Layer group (<a href="http://leafletjs.com/reference.html#layergroup">Leaflet 
 				var feature = L.layerGroup()
 				this.feature = feature;
 				this.feature.addTo(this.container);
-				this.registerContaierOnChildren();
+				this.registerContainerOnChildren();
 			}
 		},
 
-		registerContaierOnChildren: function() {
+		registerContainerOnChildren: function() {
 			for (var i = 0; i < this.children.length; i++) {
 				this.children[i].container = this.feature;
 			}


### PR DESCRIPTION
In my testcase the layer-group is still not displayed on the map, but at least it does not throw errors causing the map to not render anymore...