### PR TITLE
Fix popup not filled with dynamic content

### DIFF
--- a/leaflet-popup.html
+++ b/leaflet-popup.html
@@ -16,7 +16,7 @@ leafletMap.LeafletPopupContent = {
 		}
 		this.feature.unbindPopup();
 		// TODO: Hack, ignore <leaflet-point>-tag
-		var content = Polymer.dom(this).innerHTML.replace(/<\/?leaflet-point[^>]*>/g, "").trim();
+		var content = this.innerHTML.replace(/<\/?leaflet-point[^>]*>/g, "").trim();
 		if (content) {
 			this.feature.bindPopup(content);
 		}


### PR DESCRIPTION
Not sure why Polymer.dom(this).innerHTML is empty while this.innerHTML is not - maybe this is a polymer issue, maybe I am doing something wrong setting the innerHTML. This (popup content not updating) happened when I did something like this : 

```javascript
ready : function() {
   var that = this;
   window.setTimeout(function(){that.injectMarkerTitle(that)},300);
},
injectMarkerTitle : function(that) {
   Polymer.dom(that.$$('leaflet-marker')).innerHTML = "<b>TEST!</b>";
   Polymer.dom.flush();
}
```

It was fixed by using this.innerHTML instead of Polymer.dom(this).innerHTML in leaflet-popup.html . Not sure if this is the best solution, but I don't see it violating polymer guidelines, they only say we have to use Polymer.dom for manipulations (https://www.polymer-project.org/1.0/docs/devguide/local-dom.html#dom-api) - this is no manipulation. 

If anyone can think for a better solution that would be awesome, as this workaround is kind of awkward.