### PR TITLE
Fire map-ready event when this.map is defined

### DIFF
--- a/leaflet-core.html
+++ b/leaflet-core.html
@@ -681,6 +681,10 @@ add a marker with a popup text.
 				zoomAnimationThreshold: this.zoomAnimationThreshold
 			});
 			this.map = map;
+			
+			// fire an event for when this.map is defined and ready.
+			// (needed for components that talk to this.map directly)
+			this.fire('map-ready');
 
 			// forward events
 			map.on('click dblclick mousedown mouseup mouseover mouseout mousemove contextmenu focus blur preclick load unload viewreset movestart move moveend dragstart drag dragend zoomstart zoomend zoomlevelschange resize autopanstart layeradd layerremove baselayerchange overlayadd overlayremove locationfound locationerror popupopen popupclose', function(e) {


### PR DESCRIPTION
I'm writing a map component which needs to look at this.map directly, so it needs to know when this.map is defined, before it starts using it.

Right now I'm doing this with Object.observe, but this doesn't have great support in all browsers.