### PR TITLE
Use attached event callback instead of the hack with domReady

### DIFF
--- a/leaflet-core.html
+++ b/leaflet-core.html
@@ -624,13 +624,6 @@ add a marker with a popup text.
 		 */
 		map: undefined,
 
-		ready: function() {
-			// TODO09: Workaround for removed domReady event
-			var me = this;
-			setTimeout(function() {me.domReady()}, 1);
-		},
-
-
 		guessLeafletImagePath: function() {
 			if (L.Icon.Default.imagePath) {
 				return;
@@ -652,7 +645,7 @@ add a marker with a popup text.
 			}
 		},
 
-		domReady: function() {
+		attached: function() {
 			this.guessLeafletImagePath();
 			var map = L.map(this.$.map, {
 				minZoom: this.minZoom,


### PR DESCRIPTION
This solves the `TODO09: Workaround for removed domReady` event from line 628

More about attached event callback can be found [here](https://www.polymer-project.org/1.0/docs/devguide/registering-elements.html).

This closes #65 
