### PR TITLE
Fix error with default icon image path

### DIFF
--- a/leaflet-core.html
+++ b/leaflet-core.html
@@ -635,21 +635,7 @@ add a marker with a popup text.
 			if (L.Icon.Default.imagePath) {
 				return;
 			}
-
-			var scripts = document.getElementsByTagName('link'),
-			    leafletRe = /[\/^]leaflet-map.html$/;
-
-			var i, len, src, matches, path;
-
-			for (i = 0, len = scripts.length; i < len; i++) {
-				src = scripts[i].href;
-				matches = src.match(leafletRe);
-
-				if (matches) {
-					path = src.split(leafletRe)[0];
-					L.Icon.Default.imagePath = (path ? path + '/' : '') + '../leaflet/dist/images';
-				}
-			}
+      L.Icon.Default.imagePath = this.resolveUrl('../leaflet/dist/images');
 		},
 
 		domReady: function() {


### PR DESCRIPTION
If you try to use leaflet-map inside a component, the component fails because leaflet is not able to get the default icon image path due to leaftlet-map suppose that you are imported the component main document.

Using polymer component method resolveUrl (https://www.polymer-project.org/1.0/docs/api/Polymer.Base#method-resolveUrl) you can get the URL of a component and use it to get the correct icon default URL.